### PR TITLE
fix: quote strings containing hashtag

### DIFF
--- a/resources/envvars
+++ b/resources/envvars
@@ -10,3 +10,4 @@ EMPTY_QUOTED=''
 EMPTY_DOUBLE_QUOTED=""
 JSON={"a":"b", "c":"d"}
 MULTILINE="lorem ipsum\ndolor sit amet..."
+CONTAINS_HASH_TAG="abc#123"

--- a/resources/envvars-normalized
+++ b/resources/envvars-normalized
@@ -10,3 +10,4 @@ EMPTY_QUOTED=
 EMPTY_DOUBLE_QUOTED=
 JSON={"a":"b", "c":"d"}
 MULTILINE="lorem ipsum\ndolor sit amet..."
+CONTAINS_HASH_TAG="abc#123"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const quote = /[\s"']/
+const quote = /[\s"'#]/
 
 function stringifyPair ([key, val]) {
   let strval = ''

--- a/src/stringify.test.js
+++ b/src/stringify.test.js
@@ -3,8 +3,8 @@ import fs from 'fs'
 import dotenv from 'dotenv'
 import stringify from './index'
 
-const envStr = fs.readFileSync(path.resolve('./resources/envvars')).toString()
-const envStrNorm = fs.readFileSync(path.resolve('./resources/envvars-normalized')).toString()
+const envStr = fs.readFileSync(path.resolve('./resources/envvars')).toString().trim()
+const envStrNorm = fs.readFileSync(path.resolve('./resources/envvars-normalized')).toString().trim()
 const envObj = dotenv.parse(envStr)
 
 describe('stringify()', () => {


### PR DESCRIPTION
If an env var contains "#" it should be quoted so that it's not treated as a comment.

I also updated the test files for this, and because my IDE adds a newline / blank line to the end of the file I made the tests trim the file contents so the tests still pass.